### PR TITLE
Change to use `SetFileAttributesW`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.3.0\...HEAD[Unreleased]
+
+=== Fixed
+
+* Fix not being able to take path of Unicode string in Windows environment
+  ({pull-request-url}/90[#90])
+
 == {compare-url}/v0.2.2\...v0.3.0[0.3.0] - 2024-03-28
 
 === Added

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -78,8 +78,7 @@ pub fn is_hidden(path: impl AsRef<Path>) -> io::Result<bool> {
 /// Returns [`Err`] if any of the following are true:
 ///
 /// - Metadata about a file could not be obtained.
-/// - `path` contains the null character.
-/// - The [`SetFileAttributesA`] function fails.
+/// - The [`SetFileAttributesW`] function fails.
 ///
 /// # Examples
 ///
@@ -123,7 +122,7 @@ pub fn is_hidden(path: impl AsRef<Path>) -> io::Result<bool> {
 /// # }
 /// ```
 ///
-/// [`SetFileAttributesA`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesa
+/// [`SetFileAttributesW`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw
 pub fn hide(path: impl AsRef<Path>) -> io::Result<()> {
     imp::hide(path.as_ref())
 }
@@ -145,8 +144,7 @@ pub fn hide(path: impl AsRef<Path>) -> io::Result<()> {
 /// Returns [`Err`] if any of the following are true:
 ///
 /// - Metadata about a file could not be obtained.
-/// - `path` contains the null character.
-/// - The [`SetFileAttributesA`] function fails.
+/// - The [`SetFileAttributesW`] function fails.
 ///
 /// # Examples
 ///
@@ -196,7 +194,7 @@ pub fn hide(path: impl AsRef<Path>) -> io::Result<()> {
 /// # }
 /// ```
 ///
-/// [`SetFileAttributesA`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesa
+/// [`SetFileAttributesW`]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesw
 pub fn show(path: impl AsRef<Path>) -> io::Result<()> {
     imp::show(path.as_ref())
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Fix not being able to take path of Unicode string in Windows environment.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/hf/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/hf/blob/develop/CODE_OF_CONDUCT.md
